### PR TITLE
Added API authentication to all create and update endpoints.

### DIFF
--- a/app/api/api_v1/endpoints/addresses.py
+++ b/app/api/api_v1/endpoints/addresses.py
@@ -1,12 +1,14 @@
-from app.schemas.misc import GeneralResponse
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.api.dependencies import get_db
+from app.api.dependencies import get_db, get_api_key
 from app.db.database import MSSQLConnection
-from app.schemas.addresses import AddressCreateRequest, AddressResponse, AddressFilterParams, AddressUpdateRequest
+from app.schemas.addresses import AddressCreateRequest, AddressResponse, \
+    AddressFilterParams, AddressUpdateRequest
+from app.schemas.misc import GeneralResponse
 from app.services.addresses import AddressService
+from uuid import UUID
 
 router = APIRouter()
 
@@ -26,7 +28,8 @@ async def list_addresses(
     response_model=AddressResponse,
     responses={
         status.HTTP_404_NOT_FOUND: {
-            "description": "The address with the specified id could not be found."
+            "description": "The address with the specified id could not be "
+                           "found. "
         }
     },
 )
@@ -40,32 +43,50 @@ async def retrieve_address_by_id(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return address
 
-@router.post("", response_model=GeneralResponse)
+
+@router.post(
+    "",
+    response_model=GeneralResponse,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        }
+    },
+)
 async def create_address(
     body: AddressCreateRequest,
     db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
-    await AddressService(db).create(body)
+    await AddressService(db).create(body, auth_key=api_key)
 
     return GeneralResponse(success=True)
+
 
 @router.put(
     "/{address_id}",
     response_model=GeneralResponse,
     responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        },
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
 async def update_address(
     address_id: int,
     body: AddressUpdateRequest,
-    db: MSSQLConnection = Depends(get_db)
+    db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
     requirement = await AddressService(db).update(
-        id=address_id,
-        params=body)
+        identifier=address_id,
+        params=body,
+        auth_key=api_key
+    )
 
     if requirement is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/app/api/api_v1/endpoints/locations.py
+++ b/app/api/api_v1/endpoints/locations.py
@@ -1,12 +1,14 @@
-from app.schemas.misc import GeneralResponse
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.api.dependencies import get_db
+from app.api.dependencies import get_db, get_api_key
 from app.db.database import MSSQLConnection
-from app.schemas.locations import LocationCreateRequest, LocationExpandedResponse, LocationFilterParams, LocationUpdateRequest
+from app.schemas.locations import LocationCreateRequest, \
+    LocationExpandedResponse, LocationFilterParams, LocationUpdateRequest
+from app.schemas.misc import GeneralResponse
 from app.services.locations import LocationService
+from uuid import UUID
 
 router = APIRouter()
 
@@ -26,7 +28,8 @@ async def list_locations(
     response_model=LocationExpandedResponse,
     responses={
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
@@ -40,32 +43,50 @@ async def retrieve_location_by_id(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return location
 
-@router.post("", response_model=GeneralResponse)
+
+@router.post(
+    "",
+    response_model=GeneralResponse,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        }
+    },
+)
 async def create_location(
     body: LocationCreateRequest,
     db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
-    await LocationService(db).create(body)
+    await LocationService(db).create(body, auth_key=api_key)
 
     return GeneralResponse(success=True)
+
 
 @router.put(
     "/{location_id}",
     response_model=GeneralResponse,
     responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        },
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
 async def update_location(
     location_id: int,
     body: LocationUpdateRequest,
-    db: MSSQLConnection = Depends(get_db)
+    db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
     requirement = await LocationService(db).update(
-        id=location_id,
-        params=body)
+        identifier=location_id,
+        params=body,
+        auth_key=api_key
+    )
 
     if requirement is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/app/api/api_v1/endpoints/organizations.py
+++ b/app/api/api_v1/endpoints/organizations.py
@@ -2,7 +2,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.api.dependencies import get_db
+from app.api.dependencies import get_db, get_api_key
 from app.db.database import MSSQLConnection
 from app.schemas.misc import GeneralResponse
 from app.schemas.organizations import (
@@ -12,6 +12,7 @@ from app.schemas.organizations import (
     OrganizationUpdateRequest,
 )
 from app.services.organizations import OrganizationService
+from uuid import UUID
 
 router = APIRouter()
 
@@ -31,7 +32,8 @@ async def list_organizations(
     response_model=OrganizationResponse,
     responses={
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
@@ -46,32 +48,49 @@ async def retrieve_organization_by_id(
     return organization
 
 
-@router.post("", response_model=GeneralResponse)
+@router.post(
+    "",
+    response_model=GeneralResponse,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        }
+    },
+)
 async def create_organization(
     body: OrganizationCreateRequest,
     db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
-    await OrganizationService(db).create(body)
+    await OrganizationService(db).create(body, api_key)
 
     return GeneralResponse(success=True)
+
 
 @router.put(
     "/{organization_id}",
     response_model=GeneralResponse,
     responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        },
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
 async def update_organization(
     organization_id: int,
     body: OrganizationUpdateRequest,
-    db: MSSQLConnection = Depends(get_db)
+    db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
     organization = await OrganizationService(db).update(
-        id=organization_id,
-        params=body)
+        identifier=organization_id,
+        params=body,
+        auth_key=api_key
+    )
 
     if organization is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/app/api/api_v1/endpoints/requirements.py
+++ b/app/api/api_v1/endpoints/requirements.py
@@ -1,12 +1,14 @@
-from app.schemas.misc import GeneralResponse
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.api.dependencies import get_db
+from app.api.dependencies import get_db, get_api_key
 from app.db.database import MSSQLConnection
-from app.schemas.requirements import RequirementResponse, RequirementsCreateRequest, RequirementsUpdateRequest
+from app.schemas.misc import GeneralResponse
+from app.schemas.requirements import RequirementResponse, \
+    RequirementsCreateRequest, RequirementsUpdateRequest
 from app.services.requirements import RequirementService
+from uuid import UUID
 
 router = APIRouter()
 
@@ -25,7 +27,8 @@ async def list_requirements(
     response_model=RequirementResponse,
     responses={
         status.HTTP_404_NOT_FOUND: {
-            "description": "The requirement with the specified id could not be found."
+            "description": "The requirement with the specified id could not "
+                           "be found. "
         }
     },
 )
@@ -40,32 +43,49 @@ async def retrieve_requirement_by_id(
     return requirement
 
 
-@router.post("", response_model=GeneralResponse)
+@router.post(
+    "",
+    response_model=GeneralResponse,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        }
+    },
+)
 async def create_requirement(
     body: RequirementsCreateRequest,
     db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
-    await RequirementService(db).create(body)
+    await RequirementService(db).create(body, api_key)
 
     return GeneralResponse(success=True)
+
 
 @router.put(
     "/{requirement_id}",
     response_model=GeneralResponse,
     responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        },
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
 async def update_requirement(
     requirement_id: int,
     body: RequirementsUpdateRequest,
-    db: MSSQLConnection = Depends(get_db)
+    db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
     requirement = await RequirementService(db).update(
-        id=requirement_id,
-        params=body)
+        identifier=requirement_id,
+        params=body,
+        auth_key=api_key
+    )
 
     if requirement is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/app/api/api_v1/endpoints/vaccine_availability.py
+++ b/app/api/api_v1/endpoints/vaccine_availability.py
@@ -1,12 +1,11 @@
-from app.services.vaccine_availability_requirement import VaccineAvailabilityRequirementService
-from app.schemas.misc import GeneralResponse
 from typing import List
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.api.dependencies import get_db
+from app.api.dependencies import get_db, get_api_key
 from app.db.database import MSSQLConnection
+from app.schemas.misc import GeneralResponse
 from app.schemas.vaccine_availability import (
     VaccineAvailabilityCreateRequest,
     VaccineAvailabilityExpandedResponse,
@@ -22,14 +21,18 @@ from app.schemas.vaccine_availability import (
     VaccineAvailabilityUpdateRequest,
 )
 from app.services.vaccine_availability import VaccineAvailabilityService
-from app.services.vaccine_availability_timeslot import VaccineAvailabilityTimeslotService
+from app.services.vaccine_availability_requirement import \
+    VaccineAvailabilityRequirementService
+from app.services.vaccine_availability_timeslot import \
+    VaccineAvailabilityTimeslotService
 
 router = APIRouter()
 
 
 @router.get("", response_model=List[VaccineAvailabilityExpandedResponse])
 async def list_vaccine_availability(
-    postalCode: str = "", db: MSSQLConnection = Depends(get_db)
+    postalCode: str = "",
+    db: MSSQLConnection = Depends(get_db)
 ) -> List[VaccineAvailabilityExpandedResponse]:
     return await VaccineAvailabilityService(db).get_all_expanded(
         filters=VaccineAvailabilityFilterParams(
@@ -43,7 +46,8 @@ async def list_vaccine_availability(
     response_model=VaccineAvailabilityExpandedResponse,
     responses={
         status.HTTP_404_NOT_FOUND: {
-            "description": "The vaccine availability with the specified id could not be found."
+            "description": "The vaccine availability with the specified id "
+                           "could not be found. "
         }
     },
 )
@@ -51,54 +55,75 @@ async def retrieve_vaccine_availability_by_id(
     vaccine_availability_id: UUID,
     db: MSSQLConnection = Depends(get_db)
 ) -> VaccineAvailabilityExpandedResponse:
-    entry = await VaccineAvailabilityService(db).get_by_id_expanded(vaccine_availability_id)
+    entry = await VaccineAvailabilityService(db).get_by_id_expanded(
+        vaccine_availability_id
+    )
 
     if entry is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return entry
 
-@router.post("", response_model=GeneralResponse)
+
+@router.post(
+    "",
+    response_model=GeneralResponse,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        }
+    },
+)
 async def create_vaccine_availability(
     body: VaccineAvailabilityCreateRequest,
     db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
-    await VaccineAvailabilityService(db).create(body)
+    await VaccineAvailabilityService(db).create(body, api_key)
 
     return GeneralResponse(success=True)
+
 
 @router.put(
     "/{vaccine_availability_id}",
     response_model=GeneralResponse,
     responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        },
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
 async def update_vaccine_availability(
     vaccine_availability_id: int,
     body: VaccineAvailabilityUpdateRequest,
-    db: MSSQLConnection = Depends(get_db)
+    db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
     requirement = await VaccineAvailabilityService(db).update(
-        id=vaccine_availability_id,
-        params=body)
+        identifier=vaccine_availability_id,
+        params=body,
+        auth_key=api_key
+    )
 
     if requirement is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return GeneralResponse(success=True)
 
+
 # ------------------------- Timeslots -------------------------
-#region
 @router.get(
     "/{vaccine_availability_id}/timeslots",
     response_model=List[VaccineAvailabilityTimeslotResponse],
     responses={
         status.HTTP_404_NOT_FOUND: {
-            "description": "The vaccine availability with the specified id could not be found."
+            "description": "The vaccine availability with the specified id "
+                           "could not be found. "
         }
     },
-) 
+)
 async def retrieve_vaccine_availability_timeslots(
     vaccine_availability_id: UUID,
     db: MSSQLConnection = Depends(get_db)
@@ -114,22 +139,37 @@ async def retrieve_vaccine_availability_timeslots(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return entry
 
-@router.post("/{vaccine_availability_id}/timeslots", response_model=GeneralResponse)
+
+@router.post(
+    "/{vaccine_availability_id}/timeslots",
+    response_model=GeneralResponse,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        }
+    },
+)
 async def create_vaccine_availability_timeslot(
     vaccine_availability_id: UUID,
     body: VaccineAvailabilityTimeslotCreateRequest,
     db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
-    await VaccineAvailabilityTimeslotService(db).create(body)
+    await VaccineAvailabilityTimeslotService(db).create(body, api_key)
 
     return GeneralResponse(success=True)
+
 
 @router.put(
     "/{vaccine_availability_id}/timeslots/{timeslot_id}",
     response_model=GeneralResponse,
     responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        },
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
@@ -137,25 +177,28 @@ async def update_vaccine_availability_timeslot(
     vaccine_availability_id: UUID,
     timeslot_id: UUID,
     body: VaccineAvailabilityTimeslotUpdateRequest,
-    db: MSSQLConnection = Depends(get_db)
+    db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
     requirement = await VaccineAvailabilityTimeslotService(db).update(
-        id=timeslot_id,
-        params=body)
+        identifier=timeslot_id,
+        params=body,
+        auth_key=api_key
+    )
 
     if requirement is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return GeneralResponse(success=True)
-#endregion
+
 
 # ------------------------- Requirements -------------------------
-#region
 @router.get(
     "/{vaccine_availability_id}/requirements",
     response_model=List[VaccineAvailabilityRequirementsResponse],
     responses={
         status.HTTP_404_NOT_FOUND: {
-            "description": "The vaccine availability with the specified id could not be found."
+            "description": "The vaccine availability with the specified id "
+                           "could not be found. "
         }
     },
 )
@@ -174,22 +217,37 @@ async def retrieve_vaccine_availability_requirements(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return entry
 
-@router.post("/{vaccine_availability_id}/requirements", response_model=GeneralResponse)
+
+@router.post(
+    "/{vaccine_availability_id}/requirements",
+    response_model=GeneralResponse,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        }
+    },
+)
 async def create_vaccine_availability_requirement(
     vaccine_availability_id: UUID,
     body: VaccineAvailabilityRequirementsCreateRequest,
     db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
-    await VaccineAvailabilityRequirementService(db).create(body)
+    await VaccineAvailabilityRequirementService(db).create(body, api_key)
 
     return GeneralResponse(success=True)
+
 
 @router.put(
     "/{vaccine_availability_id}/requirements/{requirement_id}",
     response_model=GeneralResponse,
     responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Invalid credentials."
+        },
         status.HTTP_404_NOT_FOUND: {
-            "description": "The location with the specified id could not be found."
+            "description": "The location with the specified id could not be "
+                           "found. "
         }
     },
 )
@@ -197,13 +255,15 @@ async def update_vaccine_availability_requirement(
     vaccine_availability_id: UUID,
     requirement_id: UUID,
     body: VaccineAvailabilityRequirementsUpdateRequest,
-    db: MSSQLConnection = Depends(get_db)
+    db: MSSQLConnection = Depends(get_db),
+    api_key: UUID = Depends(get_api_key)
 ) -> GeneralResponse:
     requirement = await VaccineAvailabilityRequirementService(db).update(
-        id=requirement_id,
-        params=body)
+        identifier=requirement_id,
+        params=body,
+        auth_key=api_key
+    )
 
     if requirement is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return GeneralResponse(success=True)
-#endregion

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -1,9 +1,19 @@
 from typing import AsyncGenerator
 from app.core.config import settings
 from app.db.database import MSSQLBackend, MSSQLConnection
+from fastapi.security import APIKeyHeader
+from fastapi import Security, HTTPException, status
+from typing import Optional
+from uuid import UUID
+
+auth_header = APIKeyHeader(name="Authorization", auto_error=False)
 
 
 async def get_db() -> AsyncGenerator[MSSQLConnection, None]:
+    """
+    Returns a database object that will subsequently be used for making queries
+    to the database for each HTTP request.
+    """
     db = MSSQLBackend(settings.DB_URL)
     await db.connect()
     try:
@@ -13,3 +23,36 @@ async def get_db() -> AsyncGenerator[MSSQLConnection, None]:
     finally:
         await connection.release()
         await db.disconnect()
+
+
+async def get_api_key(
+    auth_value: Optional[str] = Security(auth_header)
+) -> UUID:
+    """
+    Returns an API key from the Authorization header. The syntax for this
+    header's value is `<type> <credentials>`. The Bearer authentication scheme
+    is described by RFC6750 for OAuth 2.0 but we can still use it since the
+    terminology of a Bearer token is described as:
+    "A security token with the property that any party in possession of the
+    token (a "bearer") can use the token in any way that any other party in
+    possession of it can. Using a bearer token does not require a bearer to
+    prove possession of cryptographic key material (proof-of-possession)."
+    """
+    auth_credentials = None
+    if auth_value is not None:
+        auth_values = auth_value.split()
+        if len(auth_values) == 2 and auth_values[0].lower() == "bearer":
+            try:
+                # The authentication credentials must be a UUID
+                auth_credentials = UUID(auth_values[1])
+            except ValueError:
+                pass
+
+    if auth_credentials is None:
+        # Give generic error for security reasons
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials."
+        )
+
+    return auth_credentials

--- a/app/schemas/addresses.py
+++ b/app/schemas/addresses.py
@@ -9,6 +9,7 @@ from app.schemas.misc import FilterParamsBase
 class AddressFilterParams(FilterParamsBase):
     postalCode: str
 
+
 class AddressResponseBase(BaseModel):
     line1: Optional[str]
     line2: Optional[str]
@@ -17,12 +18,15 @@ class AddressResponseBase(BaseModel):
     province: str
     postcode: str
 
+
 class AddressResponse(AddressResponseBase):
     id: int
     created_at: datetime
 
+
 class AddressCreateRequest(AddressResponseBase):
-    auth: str
+    pass
+
 
 class AddressUpdateRequest(AddressResponseBase):
     id: int

--- a/app/schemas/locations.py
+++ b/app/schemas/locations.py
@@ -1,4 +1,3 @@
-from app.schemas.organizations import OrganizationResponse
 from datetime import datetime
 from typing import Optional
 
@@ -6,6 +5,7 @@ from pydantic import BaseModel
 
 from app.schemas.addresses import AddressResponse
 from app.schemas.misc import FilterParamsBase
+from app.schemas.organizations import OrganizationResponse
 
 
 class LocationFilterParams(FilterParamsBase):
@@ -34,10 +34,11 @@ class LocationExpandedResponse(LocationResponseBase):
     organization: Optional[OrganizationResponse]
     address: Optional[AddressResponse]
 
+
 class LocationCreateRequest(LocationResponseBase):
     organization: Optional[int]
     address: Optional[int]
-    auth: str
+
 
 class LocationUpdateRequest(LocationResponseBase):
     id: int

--- a/app/schemas/misc.py
+++ b/app/schemas/misc.py
@@ -1,11 +1,15 @@
-from pydantic import BaseModel
 from typing import Union, Literal
+
+from pydantic import BaseModel
+
 
 class GeneralResponse(BaseModel):
     success: bool
     data: Union[str, None] = None
 
+
 MatchType = Literal['exact']
+
 
 class FilterParamsBase(BaseModel):
     match_type: MatchType

--- a/app/schemas/organizations.py
+++ b/app/schemas/organizations.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, AnyUrl
+from pydantic import BaseModel
 
 from app.schemas.misc import FilterParamsBase
 
@@ -9,19 +9,23 @@ from app.schemas.misc import FilterParamsBase
 class OrganizationFilterParams(FilterParamsBase):
     name: str
 
+
 class OrganizationBase(BaseModel):
     full_name: Optional[str]
     short_name: str
     description: Optional[str]
     url: Optional[str]
 
+
 class OrganizationResponse(OrganizationBase):
     id: int
     created_at: datetime
 
+
 class OrganizationCreateRequest(OrganizationBase):
-    auth: str
+    pass
+
 
 class OrganizationUpdateRequest(OrganizationBase):
     # organizationID: int
-    auth: str
+    pass

--- a/app/schemas/requirements.py
+++ b/app/schemas/requirements.py
@@ -2,17 +2,20 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+
 class RequirementResponseBase(BaseModel):
     name: str
     description: str
+
 
 class RequirementResponse(RequirementResponseBase):
     id: int
     created_at: datetime
 
+
 class RequirementsCreateRequest(RequirementResponseBase):
-    auth: str
+    pass
+
 
 class RequirementsUpdateRequest(RequirementResponseBase):
     id: int
-    auth: str

--- a/app/schemas/vaccine_availability.py
+++ b/app/schemas/vaccine_availability.py
@@ -12,6 +12,7 @@ from app.schemas.misc import FilterParamsBase
 class VaccineAvailabilityFilterParams(FilterParamsBase):
     postalCode: str
 
+
 class VaccineAvailabilityResponseBase(BaseModel):
     numberAvailable: Optional[int]
     numberTotal: Optional[int]
@@ -32,17 +33,18 @@ class VaccineAvailabilityExpandedResponse(VaccineAvailabilityResponseBase):
     location: LocationExpandedResponse
     created_at: datetime
 
+
 class VaccineAvailabilityCreateRequest(VaccineAvailabilityResponseBase):
     location: int
-    auth: str
+
 
 class VaccineAvailabilityUpdateRequest(VaccineAvailabilityResponseBase):
     id: Union[UUID, int]
     location: int
-    auth: str
+
 
 # ------------------------- Timeslots -------------------------
-#region 
+# region
 class VaccineAvailabilityTimeslotResponse(BaseModel):
     id: UUID
     vaccine_availability: UUID
@@ -51,21 +53,25 @@ class VaccineAvailabilityTimeslotResponse(BaseModel):
     created_at: datetime
     time: datetime
 
+
 class VaccineAvailabilityTimeslotCreateRequest(BaseModel):
     parentID: UUID
-    auth: str
     time: datetime
+
 
 class VaccineAvailabilityTimeslotUpdateRequest(BaseModel):
     # auth: str
     taken_at: Optional[datetime]
 
+
 class VaccineAvailabilityTimeslotFilterParams(FilterParamsBase):
     vaccine_availability: UUID
-#endregion
+
+
+# endregion
 
 # ------------------------- Requirements -------------------------
-#region
+# region
 
 class VaccineAvailabilityRequirementsResponse(BaseModel):
     id: int
@@ -74,12 +80,15 @@ class VaccineAvailabilityRequirementsResponse(BaseModel):
     active: bool
     created_at: datetime
 
+
 class VaccineAvailabilityRequirementsCreateRequest(BaseModel):
     requirements: List[int]
+
 
 class VaccineAvailabilityRequirementsUpdateRequest(BaseModel):
     active: bool
 
+
 class VaccineAvailabilityRequirementsFilterParams(FilterParamsBase):
     vaccine_availability: UUID
-#endregion
+# endregion

--- a/app/services/vaccine_availability_requirement.py
+++ b/app/services/vaccine_availability_requirement.py
@@ -37,7 +37,7 @@ class VaccineAvailabilityRequirementService(
     def update_response_schema(self) -> Type[VaccineAvailabilityRequirementsUpdateRequest]:
         return VaccineAvailabilityRequirementsUpdateRequest
 
-    async def get_by_id(self, id: Union[UUID, int]) -> None:
+    async def get_by_id(self, identifier: Union[UUID, int]) -> None:
         raise NotImplementedError('Get by ID is not available for requirements')
 
     # async def get_all(

--- a/app/services/vaccine_availability_timeslot.py
+++ b/app/services/vaccine_availability_timeslot.py
@@ -37,7 +37,7 @@ class VaccineAvailabilityTimeslotService(
     def update_response_schema(self) -> Type[VaccineAvailabilityTimeslotUpdateRequest]:
         return VaccineAvailabilityTimeslotUpdateRequest
 
-    async def get_by_id(self, id: Union[UUID, int]) -> None:
+    async def get_by_id(self, identifier: Union[UUID, int]) -> None:
         raise NotImplementedError('Get by ID is not available for timeslots')
 
     # async def get_all(


### PR DESCRIPTION
**Authentication added to create and update endpoints.** From now on, to create, update and delete from REST endpoints, one must place an `Authorization` header within their request of the format `Bearer <API Key>`.

- Added dependency `get_api_key()` in `app/api_v1/dependencies.py`. This returns the API key (a UUID) and throws an exception (401) if credentials are incorrect.
- OpenAPI specification reflects API key in Header (i.e. **Authorize** button in Swagger docs)
- All create and update endpoints placed with the `get_api_key()` dependency
- `base.py` in `service` directs the key into the stored procedures
- Some formatting changes along the way

Cheers! 🔐 