### PR TITLE
ci: add linters to actions

### DIFF
--- a/.github/workflows/main_vax-availability-api.yml
+++ b/.github/workflows/main_vax-availability-api.yml
@@ -11,12 +11,38 @@ on:
   workflow_dispatch:
 
 jobs:
-  Build:
+  BuildAndTest:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repo
+      uses: actions/checkout@v2
 
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v2.1.0
+      with:
+        poetry-version: 1.1.6
+
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Run linters (mypy, black, isort)
+      run: |
+       poetry run mypy --config-file mypy.ini .
+       poetry run black --line-length 79 --check .
+       poetry run isort --profile black --line-length 79 --multi-line 3 \
+         --filter-files --check --diff .
+
+  BuildDocker:
+    runs-on: 'ubuntu-latest'
+    needs: BuildAndTest
+
+    steps:
     - name: Set up Docker Build
       uses: docker/setup-buildx-action@v1
 
@@ -37,7 +63,7 @@ jobs:
 
   DeployStaging:
     runs-on: ubuntu-latest
-    needs: Build
+    needs: BuildDocker
     environment:
       name: 'staging'
       url: ${{ steps.deploy-to-webapp-staging.outputs.webapp-url }}


### PR DESCRIPTION
Per conversations with some of the team, it seems we're going to want to slowly add some more testing and validation in our CI. One thing we can immediately do is add some of the linters, which I've done here. This will add `mypy`, `black`, and `isort` checking on `main` and `staging` branches. Hopefully people all install the `pre-commit` scripts, but you never know.

Since the actual application is contained within a Docker container, none of the actual build tools exist on the runner. I've decided the best way for now might be to directly install `poetry`, and mimic a `pre-commit` workflow with only checking enabled.

Using `poetry` directly means we have one source of truth when it comes to the various versions of the linting tools. However, this conversely means we'll have to keep track of the version of `poetry` in the `Dockerfile` and the GitHub CI actions file, and also keep track of the CLI options to the various linting tools. These things shouldn't change too much, however, and I don't think it's the biggest headache. If we really want to be draconian with keeping everything bound to one source of truth, we could create a separate CI shell script that will have all the steps for linting and have both `pre-commit` and the GitHub actions file reference that instead. This would be doubly nice in the future when we want real tests, and don't want to expect devs to memorize obscure `pytest` commands or something, but rather just use a premade script. Don't think it's a big need right now though.

I'd also suggest possibly something like `yamllint` since we use so many YAML config files, but I'm open to suggestions for otherwise.