### PR TITLE
ci: re-add git checkout to DockerBuild step

### DIFF
--- a/.github/workflows/main_vax-availability-api.yml
+++ b/.github/workflows/main_vax-availability-api.yml
@@ -43,6 +43,9 @@ jobs:
     needs: BuildAndTest
 
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
     - name: Set up Docker Build
       uses: docker/setup-buildx-action@v1
 


### PR DESCRIPTION
I forgot the `checkout` step in the `BuildDocker`. I assumed the docker setup action would do that, but I assumed too much. I wasn't able to test this on my local fork because I didn't set up my own docker repo for the container. Apologies about that.

I set up a mock `vax-hunters-api` Docker hub repo on my personal account, and have confirmed that the build and build docker portions work: https://github.com/rayraykay/VaxFinder-backend/actions/runs/832614593
Obviously I can't check the staging and production deployment parts, but I haven't touched those in the YAML, and the successful docker build should mean they should push properly to those environments on Azure.

This should fix the CI issue.